### PR TITLE
BUG Fix: Make ZoneId required parameter

### DIFF
--- a/Sample/bicepconfig.json
+++ b/Sample/bicepconfig.json
@@ -3,7 +3,7 @@
     "localDeploy": true
   },
   "extensions": {
-    "CloudFlare": "br:cloudflarebicep.azurecr.io/cloudflare:0.1.2" // ACR
+    "CloudFlare": "br:cloudflarebicep.azurecr.io/cloudflare:0.1.9" // ACR
     // "CloudFlare": "../bin/cloudflare" // local
   },
   "implicitExtensions": []

--- a/src/Models/CloudFlareModels.cs
+++ b/src/Models/CloudFlareModels.cs
@@ -120,6 +120,6 @@ public class CloudFlareDnsRecord : CloudFlareDnsRecordIdentifiers
     [TypeProperty("Whether this record can be proxied")]
     public bool Proxiable { get; set; } = false;
 
-    [TypeProperty("The zone ID this record belongs to")]
-    public string? ZoneId { get; set; }
+    [TypeProperty("The zone ID this record belongs to", ObjectTypePropertyFlags.Required)]
+    public required string ZoneId { get; set; }
 }


### PR DESCRIPTION
Updated object type property flag for zoneId parameter, as it is a required property for DNS record types for CloudFlare DNS record creation.

Previously, it was optional, so could be missed off.